### PR TITLE
Add new figures

### DIFF
--- a/Examples/Legacy/Examples.cs
+++ b/Examples/Legacy/Examples.cs
@@ -94,11 +94,32 @@ class Program
         var size = 10000;
         var values = new double[size];
         Normal.Samples(values, 0, 2);
-        var (id, fig) = Gnuplot.Plot<Histogram>(values);
-        fig.SetColor(Color.SteelBlue);
-        fig.SetTitle("Normal distribution");
+        var (id7, fig7) = Gnuplot.Plot<Histogram>(values);
+        fig7.SetColor(Color.SteelBlue);
+        fig7.SetTitle("Normal distribution");
         Gnuplot.FillSolid(alpha: 0.4);
         Gnuplot.Show();
+        Gnuplot.Wait();
+        
+        // Gnuplot Example Vector
+        Gnuplot.CleanData();
+        var px = new List<double>();
+        var py = new List<double>();
+        var xForce = new List<double>();
+        var yForce = new List<double>();
+        var _x = Generate.LinearSpaced(20, -Math.PI,  Math.PI).ToList();
+        foreach (var xPoint in _x)
+        {
+            foreach (var yPoint in _x)
+            {
+                px.Add(xPoint);
+                py.Add(yPoint);
+                xForce.Add(0.3* xPoint / Math.Sqrt(Math.Pow(xPoint, 2) + Math.Pow(yPoint, 2) + 4));
+                yForce.Add(-0.3* yPoint / Math.Sqrt(Math.Pow(xPoint, 2) + Math.Pow(yPoint, 2) + 4));
+            }
+        }
+        var (id8, fig8) = Gnuplot.Plot<Vector>(px, py, xForce, yForce);
+        Gnuplot.Show(); 
         Gnuplot.Wait();
 
         // Gnuplot Example 2:

--- a/Examples/Legacy/Examples.cs
+++ b/Examples/Legacy/Examples.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using SharpPlot;
 using SharpPlot.Canvas.Figure;
 using SharpPlot.Utils;
+using MathNet.Numerics.Distributions;
 
 class Program
 {
@@ -71,7 +72,7 @@ class Program
         Gnuplot.Show();
         Gnuplot.Wait();
         
-        // Gnuplo Example Surface with lines
+        // Gnuplot Example Surface with lines
         Gnuplot.CleanData();
         Gnuplot.SetPlotType(PlotType.Splot);
         Gnuplot.SetIsolineDensiy(30);
@@ -85,6 +86,18 @@ class Program
         fig4.SetTitle("x**2+y**2");
         fig5.SetWidth(2.5);
         fig6.SetWidth(2.5);
+        Gnuplot.Show();
+        Gnuplot.Wait();
+        
+        // Gnuplot Example Histogram
+        Gnuplot.CleanData();
+        var size = 10000;
+        var values = new double[size];
+        Normal.Samples(values, 0, 2);
+        var (id, fig) = Gnuplot.Plot<Histogram>(values);
+        fig.SetColor(Color.SteelBlue);
+        fig.SetTitle("Normal distribution");
+        Gnuplot.FillSolid(alpha: 0.4);
         Gnuplot.Show();
         Gnuplot.Wait();
 

--- a/SharpPlot.Unittest/Canvas/Axis.cs
+++ b/SharpPlot.Unittest/Canvas/Axis.cs
@@ -111,6 +111,15 @@ namespace SharpPlot.UnitTest.Canvas
         }
 
         [Test]
+        public void TestRemoveTicks()
+        {
+            var actual = _axisTicksCompleteCttr.RemoveTicks();
+            var expected = "set ztics format ''";
+            
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
         public void TestAddTicksOneElement()
         {
             var labelValues = new Dictionary<string, double>()

--- a/SharpPlot.Unittest/Canvas/Figure.cs
+++ b/SharpPlot.Unittest/Canvas/Figure.cs
@@ -26,6 +26,7 @@ namespace SharpPlot.UnitTest.Canvas
         private Bars _bars;
         private Histogram _histogram;
         private Boxplot _boxplot;
+        private Vector _vector;
         private List<double> _x = Generate.LinearSpaced(10, 0, 10).ToList();
         private List<double> _y = Generate.LinearSpaced(10, 0, 10).Select(e => e * 2).ToList();
         private List<double> _z = Generate.LinearSpaced(10, 0, 10).Select(e => e * 4).ToList();
@@ -42,17 +43,17 @@ namespace SharpPlot.UnitTest.Canvas
             _scatter2D = new Scatter2D();
             _scatter3D = new Scatter3D()
             {
-                ArrX = _x, ArrY = _y, ArrZ = _z
+                ArrX = _x, ArrY = _y, ArrZ1 = _z
             };
             _line2D = new Line2D();
             _filledCurves = new FilledCurves()
             {
-                ArrX = _x, ArrY = _y, ArrZ = _z
+                ArrX = _x, ArrY = _y, ArrZ1 = _z
             };
             _linePoints2D = new LinePoints2D();
             _yError = new YError()
             {
-                ArrX = _x, ArrY = _y, ArrZ = _z
+                ArrX = _x, ArrY = _y, ArrZ1 = _z
             };
             _line3D = new Line3D();
             _linePoints3D = new LinePoints3D();
@@ -70,6 +71,10 @@ namespace SharpPlot.UnitTest.Canvas
             _boxplot = new Boxplot()
             {
                 ArrX = _array
+            };
+            _vector = new Vector()
+            {
+                ArrX = _x, ArrY = _y, ArrZ1 = _z, ArrZ2 = _z
             };
             
         }
@@ -277,6 +282,19 @@ namespace SharpPlot.UnitTest.Canvas
             var expectedDataPoints = _histogram.ArrX.Select(t => $"{t}").ToList();
             expectedDataPoints.Add("e" + Environment.NewLine);
             Assert.AreEqual(expectedDataPoints, _boxplot.DataPoints);
+        }
+
+        [Test]
+        public void TestVector()
+        {
+            var expectedOps = $"u 1:2:3:4 with vector lw {_vector.Properties.Width} " +
+                              $"lc rgb '{_vector.Properties.Color.ToString().ToLower()}'";
+            
+            Assert.AreEqual(expectedOps, _vector.Options);
+            
+            var expectedDataPoints = _x.Select((t, idx) => $"{t} {_y[idx]} {_z[idx]} {_z[idx]}").ToList();
+            expectedDataPoints.Add("e" + Environment.NewLine);
+            Assert.AreEqual(expectedDataPoints, _vector.DataPoints);
         }
         
     }

--- a/SharpPlot.Unittest/Canvas/Figure.cs
+++ b/SharpPlot.Unittest/Canvas/Figure.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using MathNet.Numerics;
+using MathNet.Numerics.Distributions;
 using NUnit.Framework;
 using SharpPlot.Canvas.Figure;
 using SharpPlot.Utils;
@@ -21,9 +22,11 @@ namespace SharpPlot.UnitTest.Canvas
         private Impulse _impulse;
         private Function _function;
         private Bars _bars;
+        private Histogram _histogram;
         private List<double> _x = Generate.LinearSpaced(10, 0, 10).ToList();
         private List<double> _y = Generate.LinearSpaced(10, 0, 10).Select(e => e * 2).ToList();
         private List<double> _z = Generate.LinearSpaced(10, 0, 10).Select(e => e * 2).ToList();
+        private double[] _array = new double[1000];
         private string _f = "x**2+y**2";
         
         [SetUp]
@@ -48,6 +51,11 @@ namespace SharpPlot.UnitTest.Canvas
                 Properties = {Function = _f}
             };
             _bars = new Bars();
+            Normal.Samples(_array, mean: 0, stddev: 1);
+            _histogram = new Histogram()
+            {
+                ArrX = _array
+            };
             
         }
 
@@ -203,6 +211,21 @@ namespace SharpPlot.UnitTest.Canvas
         {
             var expectedOps = $"u 1:2:({_bars.Properties.Width}) with boxes lc rgb '{_bars.Properties.Color.ToString().ToLower()}'";
             Assert.AreEqual(expectedOps, _bars.Options);
+        }
+
+        [Test]
+        public void TestHistogram()
+        {
+            var expectedOps = $"u 1:({_histogram.Properties.Width}) smooth freq with boxes " +
+                              $"lc rgb '{_histogram.Properties.Color.ToString().ToLower()}'";
+            Assert.AreEqual(expectedOps, _histogram.Options);
+
+            var x = _histogram.ArrX;
+            var bins = Math.Min(Math.Ceiling(Math.Sqrt(x.Count())), 100.0);
+            var width = (x.Max() - x.Min()) / bins;
+            var expectedDataPoints = x.Select(e => $"{width * Math.Floor(e / width) + width / 2.0}").ToList();
+            expectedDataPoints.Add("e" + Environment.NewLine);
+            Assert.AreEqual(expectedDataPoints, _histogram.DataPoints);
         }
         
     }

--- a/SharpPlot.Unittest/Canvas/Figure.cs
+++ b/SharpPlot.Unittest/Canvas/Figure.cs
@@ -20,6 +20,7 @@ namespace SharpPlot.UnitTest.Canvas
         private LinePoints3D _linePoints3D;
         private Impulse _impulse;
         private Function _function;
+        private Bars _bars;
         private List<double> _x = Generate.LinearSpaced(10, 0, 10).ToList();
         private List<double> _y = Generate.LinearSpaced(10, 0, 10).Select(e => e * 2).ToList();
         private List<double> _z = Generate.LinearSpaced(10, 0, 10).Select(e => e * 2).ToList();
@@ -46,6 +47,7 @@ namespace SharpPlot.UnitTest.Canvas
             {
                 Properties = {Function = _f}
             };
+            _bars = new Bars();
             
         }
 
@@ -194,6 +196,13 @@ namespace SharpPlot.UnitTest.Canvas
             
             var expectedOps = $" {_function.Properties.Function} lc rgb '{_function.Properties.Color.ToString().ToLower()}'";
             Assert.AreEqual(expectedOps, _function.Options);
+        }
+
+        [Test]
+        public void TestBars()
+        {
+            var expectedOps = $"u 1:2:({_bars.Properties.Width}) with boxes lc rgb '{_bars.Properties.Color.ToString().ToLower()}'";
+            Assert.AreEqual(expectedOps, _bars.Options);
         }
         
     }

--- a/SharpPlot.Unittest/Canvas/Figure.cs
+++ b/SharpPlot.Unittest/Canvas/Figure.cs
@@ -18,6 +18,7 @@ namespace SharpPlot.UnitTest.Canvas
         private Line2D _line2D;
         private FilledCurves _filledCurves;
         private LinePoints2D _linePoints2D;
+        private YError _yError;
         private Line3D _line3D;
         private LinePoints3D _linePoints3D;
         private Impulse _impulse;
@@ -49,6 +50,10 @@ namespace SharpPlot.UnitTest.Canvas
                 ArrX = _x, ArrY = _y, ArrZ = _z
             };
             _linePoints2D = new LinePoints2D();
+            _yError = new YError()
+            {
+                ArrX = _x, ArrY = _y, ArrZ = _z
+            };
             _line3D = new Line3D();
             _linePoints3D = new LinePoints3D();
             _impulse = new Impulse();
@@ -174,6 +179,18 @@ namespace SharpPlot.UnitTest.Canvas
                               $"ps {_linePoints2D.Properties.Size} pt {(int) _linePoints2D.Properties.Marker} " +
                               $"lc rgb '{_linePoints2D.Properties.Color.ToString().ToLower()}'";
             Assert.AreEqual(expectedOps, _linePoints2D.Options);
+        }
+
+        [Test]
+        public void TestYErr()
+        {
+            var expectedOps = $"u 1:2:3 with yerr ps {_yError.Properties.Size} pt {(int) _yError.Properties.Marker} " +
+                              $"lc rgb '{_yError.Properties.Color.ToString().ToLower()}'";
+            Assert.AreEqual(expectedOps, _yError.Options);
+            
+            var expectedDataPoints = _x.Select((t, idx) => $"{t} {_y[idx]} {_z[idx]}").ToList();
+            expectedDataPoints.Add("e" + Environment.NewLine);
+            Assert.AreEqual(expectedDataPoints, _yError.DataPoints);
         }
 
         [Test]

--- a/SharpPlot.Unittest/Canvas/Figure.cs
+++ b/SharpPlot.Unittest/Canvas/Figure.cs
@@ -15,6 +15,7 @@ namespace SharpPlot.UnitTest.Canvas
         private Scatter2D _scatter2D;
         private Scatter3D _scatter3D;
         private Line2D _line2D;
+        private LinePoints2D _linePoints2D;
         private Line3D _line3D;
         private Impulse _impulse;
         private Surface3D _surface3D;
@@ -36,6 +37,7 @@ namespace SharpPlot.UnitTest.Canvas
                 ArrX = _x, ArrY = _y, ArrZ = _z
             };
             _line2D = new Line2D();
+            _linePoints2D = new LinePoints2D();
             _line3D = new Line3D();
             _impulse = new Impulse();
             _surface3D = new Surface3D()
@@ -116,7 +118,7 @@ namespace SharpPlot.UnitTest.Canvas
         }
 
         [Test]
-        public void TestScatterOptions()
+        public void TestScatter2D()
         {
             var expectedOps = $"u 1:2 with points ps {_scatter2D.Properties.Size} pt {(int) _scatter2D.Properties.Marker} " +
                               $"lc rgb '{_scatter2D.Properties.Color.ToString().ToLower()}'";
@@ -124,11 +126,21 @@ namespace SharpPlot.UnitTest.Canvas
         }
 
         [Test]
-        public void TestLine2DOptions()
+        public void TestLine2D()
         {
             var expectedOps = $"u 1:2 with lines lw {_line2D.Properties.Width} dt {(int) _line2D.Properties.DashType} " +
                               $"lc rgb '{_line2D.Properties.Color.ToString().ToLower()}'";
             Assert.AreEqual(expectedOps, _line2D.Options);
+        }
+
+        [Test]
+        public void TestLinePoints2D()
+        {
+            var expectedOps = $"u 1:2 with linespoints lw {_linePoints2D.Properties.Width} dt {(int) _linePoints2D.Properties.DashType} " +
+                              $"ps {_linePoints2D.Properties.Size} pt {(int) _linePoints2D.Properties.Marker} " +
+                              $"lc rgb '{_linePoints2D.Properties.Color.ToString().ToLower()}'";
+            Assert.AreEqual(expectedOps, _linePoints2D.Options);
+            
         }
 
         [Test]

--- a/SharpPlot.Unittest/Canvas/Figure.cs
+++ b/SharpPlot.Unittest/Canvas/Figure.cs
@@ -16,6 +16,7 @@ namespace SharpPlot.UnitTest.Canvas
         private Scatter2D _scatter2D;
         private Scatter3D _scatter3D;
         private Line2D _line2D;
+        private FilledCurves _filledCurves;
         private LinePoints2D _linePoints2D;
         private Line3D _line3D;
         private LinePoints3D _linePoints3D;
@@ -23,9 +24,10 @@ namespace SharpPlot.UnitTest.Canvas
         private Function _function;
         private Bars _bars;
         private Histogram _histogram;
+        private Boxplot _boxplot;
         private List<double> _x = Generate.LinearSpaced(10, 0, 10).ToList();
         private List<double> _y = Generate.LinearSpaced(10, 0, 10).Select(e => e * 2).ToList();
-        private List<double> _z = Generate.LinearSpaced(10, 0, 10).Select(e => e * 2).ToList();
+        private List<double> _z = Generate.LinearSpaced(10, 0, 10).Select(e => e * 4).ToList();
         private double[] _array = new double[1000];
         private string _f = "x**2+y**2";
         
@@ -42,6 +44,10 @@ namespace SharpPlot.UnitTest.Canvas
                 ArrX = _x, ArrY = _y, ArrZ = _z
             };
             _line2D = new Line2D();
+            _filledCurves = new FilledCurves()
+            {
+                ArrX = _x, ArrY = _y, ArrZ = _z
+            };
             _linePoints2D = new LinePoints2D();
             _line3D = new Line3D();
             _linePoints3D = new LinePoints3D();
@@ -53,6 +59,10 @@ namespace SharpPlot.UnitTest.Canvas
             _bars = new Bars();
             Normal.Samples(_array, mean: 0, stddev: 1);
             _histogram = new Histogram()
+            {
+                ArrX = _array
+            };
+            _boxplot = new Boxplot()
             {
                 ArrX = _array
             };
@@ -146,6 +156,18 @@ namespace SharpPlot.UnitTest.Canvas
         }
 
         [Test]
+        public void TestFilledCurves()
+        {
+            var expectedOps = $"u 1:2:3 with filledcurve lw {_filledCurves.Properties.Width} " +
+                              $"dt {(int) _filledCurves.Properties.DashType} lc rgb '{_filledCurves.Properties.Color.ToString().ToLower()}'";
+            Assert.AreEqual(expectedOps, _filledCurves.Options);
+            
+            var expectedDataPoints = _x.Select((t, idx) => $"{t} {_y[idx]} {_z[idx]}").ToList();
+            expectedDataPoints.Add("e" + Environment.NewLine);
+            Assert.AreEqual(expectedDataPoints, _filledCurves.DataPoints);
+        }
+
+        [Test]
         public void TestLinePoints2D()
         {
             var expectedOps = $"u 1:2 with linespoints lw {_linePoints2D.Properties.Width} dt {(int) _linePoints2D.Properties.DashType} " +
@@ -226,6 +248,18 @@ namespace SharpPlot.UnitTest.Canvas
             var expectedDataPoints = x.Select(e => $"{width * Math.Floor(e / width) + width / 2.0}").ToList();
             expectedDataPoints.Add("e" + Environment.NewLine);
             Assert.AreEqual(expectedDataPoints, _histogram.DataPoints);
+        }
+
+        [Test]
+        public void TestBoxplot()
+        {
+            var expectedOps = $"u (0.0):1:({_boxplot.Properties.Width}) pt {(int) _boxplot.Properties.Marker} " +
+                             $"lc rgb '{_boxplot.Properties.Color.ToString().ToLower()}'";
+            Assert.AreEqual(expectedOps, _boxplot.Options);
+            
+            var expectedDataPoints = _histogram.ArrX.Select(t => $"{t}").ToList();
+            expectedDataPoints.Add("e" + Environment.NewLine);
+            Assert.AreEqual(expectedDataPoints, _boxplot.DataPoints);
         }
         
     }

--- a/SharpPlot.Unittest/Canvas/Figure.cs
+++ b/SharpPlot.Unittest/Canvas/Figure.cs
@@ -17,12 +17,13 @@ namespace SharpPlot.UnitTest.Canvas
         private Line2D _line2D;
         private LinePoints2D _linePoints2D;
         private Line3D _line3D;
+        private LinePoints3D _linePoints3D;
         private Impulse _impulse;
-        private Surface3D _surface3D;
+        private Function _function;
         private List<double> _x = Generate.LinearSpaced(10, 0, 10).ToList();
         private List<double> _y = Generate.LinearSpaced(10, 0, 10).Select(e => e * 2).ToList();
         private List<double> _z = Generate.LinearSpaced(10, 0, 10).Select(e => e * 2).ToList();
-        private string _function = "x**2+y**2";
+        private string _f = "x**2+y**2";
         
         [SetUp]
         public void SetUp()
@@ -39,10 +40,11 @@ namespace SharpPlot.UnitTest.Canvas
             _line2D = new Line2D();
             _linePoints2D = new LinePoints2D();
             _line3D = new Line3D();
+            _linePoints3D = new LinePoints3D();
             _impulse = new Impulse();
-            _surface3D = new Surface3D()
+            _function = new Function()
             {
-                Properties = {Function = _function}
+                Properties = {Function = _f}
             };
             
         }
@@ -140,7 +142,6 @@ namespace SharpPlot.UnitTest.Canvas
                               $"ps {_linePoints2D.Properties.Size} pt {(int) _linePoints2D.Properties.Marker} " +
                               $"lc rgb '{_linePoints2D.Properties.Color.ToString().ToLower()}'";
             Assert.AreEqual(expectedOps, _linePoints2D.Options);
-            
         }
 
         [Test]
@@ -168,6 +169,15 @@ namespace SharpPlot.UnitTest.Canvas
         }
 
         [Test]
+        public void TestLinePoints3D()
+        {
+            var expectedOps = $"u 1:2:3 with linespoints lw {_linePoints3D.Properties.Width} dt {(int) _linePoints3D.Properties.DashType} " +
+                              $"ps {_linePoints3D.Properties.Size} pt {(int) _linePoints3D.Properties.Marker} " +
+                              $"lc rgb '{_linePoints3D.Properties.Color.ToString().ToLower()}'";
+            Assert.AreEqual(expectedOps, _linePoints3D.Options);
+        }
+
+        [Test]
         public void TestImpulse()
         {
             var expectedOps = $"u 1:2 with impulses lw {_impulse.Properties.Width} dt {(int) _impulse.Properties.DashType} " +
@@ -176,14 +186,14 @@ namespace SharpPlot.UnitTest.Canvas
         }
 
         [Test]
-        public void TestSurface()
+        public void TestFunction()
         {
-            Assert.AreEqual(_function, _surface3D.Properties.Function);
-            Assert.AreEqual("", _surface3D.PlotInit);
-            Assert.AreEqual(new List<string>(), _surface3D.DataPoints);
+            Assert.AreEqual(_f, _function.Properties.Function);
+            Assert.AreEqual("", _function.PlotInit);
+            Assert.AreEqual(new List<string>(), _function.DataPoints);
             
-            var expectedOps = $" {_surface3D.Properties.Function} lc rgb '{_surface3D.Properties.Color.ToString().ToLower()}'";
-            Assert.AreEqual(expectedOps, _surface3D.Options);
+            var expectedOps = $" {_function.Properties.Function} lc rgb '{_function.Properties.Color.ToString().ToLower()}'";
+            Assert.AreEqual(expectedOps, _function.Options);
         }
         
     }

--- a/SharpPlot/Canvas/Axis.cs
+++ b/SharpPlot/Canvas/Axis.cs
@@ -78,6 +78,12 @@ namespace SharpPlot.Canvas
             Gnuplot.WriteCommand(ticksCommand);
         }
 
+        private void _removeTicks(AxisTicks axisTicks)
+        {
+            var removeTickscommand = axisTicks.RemoveTicks();
+            Gnuplot.WriteCommand(removeTickscommand);
+        }
+
         private static void _addTicks(Dictionary<String, double> labelValues, AxisTicks axisTicks)
         {
             List<string> commands = axisTicks.AddTicks(labelValues);
@@ -175,8 +181,20 @@ namespace SharpPlot.Canvas
             _setRange(min: ticks.Min(), max: ticks.Max(), axisRange: _zRange);
         }
         
-        //TODO: Add RemoveXTicks 
-        //set xtics format " "
+        public void RemoveXTicks()
+        {
+            _removeTicks(axisTicks: _xTicks);
+        }
+
+        public void RemoveYTicks()
+        {
+            _removeTicks(axisTicks: _yTicks);
+        }
+
+        public void RemoveZTicks()
+        {
+            _removeTicks(axisTicks: _zTicks);
+        }
         #endregion
         
         #region AddTicks
@@ -318,6 +336,13 @@ namespace SharpPlot.Canvas
             return command;
         }
 
+        private string _removeTicks()
+        {
+            string axisName = _axisName.ToString().ToLower();
+            var command = $"set {axisName}tics format ''";
+            return command;
+        }
+
         private List<string> _addTicks(Dictionary<string, double> labelValues)
         {
             string axisName = _axisName.ToString().ToLower();
@@ -342,6 +367,11 @@ namespace SharpPlot.Canvas
                 throw new ArgumentException($"ticksValues cannot be empty");
             }
             return _setTicks(ticksValues: ticksValues);
+        }
+
+        public string RemoveTicks()
+        {
+            return _removeTicks();
         }
 
         public List<string> AddTicks(Dictionary<string, double> labelValues)

--- a/SharpPlot/Canvas/Axis.cs
+++ b/SharpPlot/Canvas/Axis.cs
@@ -174,6 +174,9 @@ namespace SharpPlot.Canvas
             _setTicks(ticksValues: ticks, axisTicks: _zTicks);
             _setRange(min: ticks.Min(), max: ticks.Max(), axisRange: _zRange);
         }
+        
+        //TODO: Add RemoveXTicks 
+        //set xtics format " "
         #endregion
         
         #region AddTicks

--- a/SharpPlot/Canvas/Figure/Figure.cs
+++ b/SharpPlot/Canvas/Figure/Figure.cs
@@ -225,4 +225,16 @@ namespace SharpPlot.Canvas.Figure
 
         #endregion
     }
+
+    public class Bars : Figure
+    {
+        #region Methods
+
+        protected override string _getOptions()
+        {
+            return $"u 1:2:({Properties.Width}) with boxes lc rgb '{Properties.Color.ToString().ToLower()}'";
+        }
+        
+        #endregion
+    }
 }

--- a/SharpPlot/Canvas/Figure/Figure.cs
+++ b/SharpPlot/Canvas/Figure/Figure.cs
@@ -181,8 +181,25 @@ namespace SharpPlot.Canvas.Figure
 
         #endregion
     }
+    
+    public class LinePoints3D : Figure
+    {
+        #region Properties
+        protected internal override PlotType PlotType => PlotType.Splot;
+        #endregion
+        
+        #region Methods
 
-    public class Surface3D : Figure
+        protected override string _getOptions()
+        {
+            return $"u 1:2:3 with linespoints lw {Properties.Width} dt {(int) Properties.DashType} " +
+                   $"ps {Properties.Size} pt {(int) Properties.Marker} lc rgb '{Properties.Color.ToString().ToLower()}'";
+        }
+
+        #endregion
+    }
+
+    public class Function : Figure
     {
         #region Properties
 

--- a/SharpPlot/Canvas/Figure/Figure.cs
+++ b/SharpPlot/Canvas/Figure/Figure.cs
@@ -26,10 +26,16 @@ namespace SharpPlot.Canvas.Figure
         #endregion
     
         #region Constructors
-        protected internal Figure() {}
+
+        protected internal Figure()
+        {
+            _setUp();
+        }
         #endregion
     
         #region Methods
+
+        protected virtual void _setUp() { }
 
         private string _getHeaderPlot()
         {
@@ -207,10 +213,16 @@ namespace SharpPlot.Canvas.Figure
         protected internal override List<string> DataPoints => new List<string>();
 
         #endregion
+
+        #region Methods
+
         protected override string _getOptions()
         {
             return $" {Properties.Function} lc rgb '{Properties.Color.ToString().ToLower()}'";
         }
+
+        #endregion
+
         
     }
 
@@ -238,7 +250,9 @@ namespace SharpPlot.Canvas.Figure
         #endregion
     }
 
-    public class Histogram : Figure
+    public class Figure1D : Figure {}
+
+    public class Histogram : Figure1D
     {
         #region Properties
 
@@ -275,6 +289,38 @@ namespace SharpPlot.Canvas.Figure
             commands.Add("e" + Environment.NewLine);
             
             return commands;
+        }
+
+        #endregion
+    }
+
+    public class Boxplot : Figure1D
+    {
+        #region Properties
+
+        protected internal override List<string> DataPoints => _getBoxplotPoints();
+
+        #endregion
+        #region Methods
+
+        protected override void _setUp()
+        {
+            Gnuplot.WriteCommand("set style data boxplot");
+        }
+
+        protected override string _getOptions()
+        {
+            return $"u (0.0):1:({Properties.Width}) pt {(int) Properties.Marker} lc rgb '{Properties.Color.ToString().ToLower()}'";
+        }
+
+        private List<string> _getBoxplotPoints()
+        {
+            var commands = ArrX.Select(t => $"{t}").ToList();
+
+            commands.Add("e" + Environment.NewLine);
+            
+            return commands;
+            
         }
 
         #endregion

--- a/SharpPlot/Canvas/Figure/Figure.cs
+++ b/SharpPlot/Canvas/Figure/Figure.cs
@@ -12,7 +12,8 @@ namespace SharpPlot.Canvas.Figure
         #region Attributes
         protected internal IEnumerable<double> ArrX;
         protected internal IEnumerable<double> ArrY;
-        protected internal IEnumerable<double> ArrZ;
+        protected internal IEnumerable<double> ArrZ1;
+        protected internal IEnumerable<double> ArrZ2;
         #endregion
     
         #region Properties
@@ -63,7 +64,7 @@ namespace SharpPlot.Canvas.Figure
                     break;
                 
                 case PlotType.Splot:
-                    var z = ArrZ.ToList();
+                    var z = ArrZ1.ToList();
                     commands = x.Select((t, idx) => $"{t} {y[idx]} {z[idx]}").ToList();
                     break;
             }
@@ -164,7 +165,7 @@ namespace SharpPlot.Canvas.Figure
         {
             var x = ArrX.ToList();
             var y = ArrY.ToList();
-            var z = ArrZ.ToList();
+            var z = ArrZ1.ToList();
             var commands = x.Select((t, idx) => $"{t} {y[idx]} {z[idx]}").ToList();
             commands.Add("e" + Environment.NewLine);
 
@@ -205,7 +206,7 @@ namespace SharpPlot.Canvas.Figure
         {
             var x = ArrX.ToList();
             var y = ArrY.ToList();
-            var z = ArrZ.ToList();
+            var z = ArrZ1.ToList();
             var commands = x.Select((t, idx) => $"{t} {y[idx]} {z[idx]}").ToList();
             commands.Add("e" + Environment.NewLine);
 
@@ -378,6 +379,36 @@ namespace SharpPlot.Canvas.Figure
             
             return commands;
             
+        }
+
+        #endregion
+    }
+
+    public class Vector : Figure
+    {
+        #region Properties
+
+        protected internal override List<string> DataPoints => _getVectorPoints();
+
+        #endregion
+        
+        #region Methods
+
+        protected override string _getOptions()
+        {
+            return $"u 1:2:3:4 with vector lw {Properties.Width} lc rgb '{Properties.Color.ToString().ToLower()}'";
+        }
+
+        private List<string> _getVectorPoints()
+        {
+            var y = ArrY.ToList();
+            var z1 = ArrZ1.ToList();
+            var z2 = ArrZ2.ToList();
+            var commands = ArrX.Select((t, idx) => $"{t} {y[idx]} {z1[idx]} {z2[idx]}").ToList();
+
+            commands.Add("e" + Environment.NewLine);
+            
+            return commands;
         }
 
         #endregion

--- a/SharpPlot/Canvas/Figure/Figure.cs
+++ b/SharpPlot/Canvas/Figure/Figure.cs
@@ -139,6 +139,19 @@ namespace SharpPlot.Canvas.Figure
 
     }
 
+    public class LinePoints2D : Figure
+    {
+        #region Methods
+
+        protected override string _getOptions()
+        {
+            return $"u 1:2 with linespoints lw {Properties.Width} dt {(int) Properties.DashType} " +
+                   $"ps {Properties.Size} pt {(int) Properties.Marker} lc rgb '{Properties.Color.ToString().ToLower()}'";
+        }
+
+        #endregion
+    }
+
     public class Scatter3D : Figure
     {
         #region Properties

--- a/SharpPlot/Canvas/Figure/Figure.cs
+++ b/SharpPlot/Canvas/Figure/Figure.cs
@@ -187,6 +187,34 @@ namespace SharpPlot.Canvas.Figure
         #endregion
     }
 
+    public class YError : Figure
+    {
+        #region Properties
+
+        protected internal override List<string> DataPoints => _getDataPoints();
+
+        #endregion
+        #region Methods
+
+        protected override string _getOptions()
+        {
+            return $"u 1:2:3 with yerr ps {Properties.Size} pt {(int) Properties.Marker} lc rgb '{Properties.Color.ToString().ToLower()}'";
+        }
+        
+        private List<string> _getDataPoints()
+        {
+            var x = ArrX.ToList();
+            var y = ArrY.ToList();
+            var z = ArrZ.ToList();
+            var commands = x.Select((t, idx) => $"{t} {y[idx]} {z[idx]}").ToList();
+            commands.Add("e" + Environment.NewLine);
+
+            return commands;
+        }
+
+        #endregion
+    } 
+
     public class Scatter3D : Figure
     {
         #region Properties

--- a/SharpPlot/Canvas/Figure/Figure.cs
+++ b/SharpPlot/Canvas/Figure/Figure.cs
@@ -237,4 +237,46 @@ namespace SharpPlot.Canvas.Figure
         
         #endregion
     }
+
+    public class Histogram : Figure
+    {
+        #region Properties
+
+        protected internal override List<string> DataPoints => _getHistogramPoints();
+
+        #endregion
+        #region Methods
+
+        protected override string _getOptions()
+        {
+            return $"u 1:({Properties.Width}) smooth freq with boxes lc rgb '{Properties.Color.ToString().ToLower()}'";
+        }
+
+        private IEnumerable<double> _preparePoints()
+        {
+            var size = ArrX.Count();
+            var bins = Math.Min(Math.Ceiling(Math.Sqrt(size)), 100.0);
+            var xmax = ArrX.Max();
+            var xmin = ArrX.Min();
+            var width = (xmax - xmin) / bins;
+            var hist = ArrX.Select(e => width * Math.Floor(e / width) + width / 2.0);
+
+            Properties.Width = 0.9 * width;
+
+            return hist;
+        }
+
+        private List<string> _getHistogramPoints()
+        {
+            var x = _preparePoints();
+            
+            var commands = x.Select(t => $"{t}").ToList();
+            
+            commands.Add("e" + Environment.NewLine);
+            
+            return commands;
+        }
+
+        #endregion
+    }
 }

--- a/SharpPlot/Canvas/Figure/Figure.cs
+++ b/SharpPlot/Canvas/Figure/Figure.cs
@@ -145,6 +145,35 @@ namespace SharpPlot.Canvas.Figure
 
     }
 
+    public class FilledCurves : Figure
+    {
+        #region Properties
+
+        protected internal override List<string> DataPoints => _getDataPoints();
+
+        #endregion
+
+        #region Methods
+
+        protected override string _getOptions()
+        {
+            return $"u 1:2:3 with filledcurve lw {Properties.Width} dt {(int) Properties.DashType} lc rgb '{Properties.Color.ToString().ToLower()}'";
+        }
+
+        private List<string> _getDataPoints()
+        {
+            var x = ArrX.ToList();
+            var y = ArrY.ToList();
+            var z = ArrZ.ToList();
+            var commands = x.Select((t, idx) => $"{t} {y[idx]} {z[idx]}").ToList();
+            commands.Add("e" + Environment.NewLine);
+
+            return commands;
+        }
+
+        #endregion
+    }
+
     public class LinePoints2D : Figure
     {
         #region Methods

--- a/SharpPlot/Gnuplot.cs
+++ b/SharpPlot/Gnuplot.cs
@@ -181,9 +181,9 @@ namespace SharpPlot
             WriteCommand("set hidden3d");
         }
 
-        public static void FillSolid()
+        public static void FillSolid(double alpha=1)
         {
-            WriteCommand("set style fill solid");
+            WriteCommand($"set style fill solid {alpha}");
         }
 
         private static bool _checkCommensurability(IEnumerable<IEnumerable<double>> z)
@@ -194,6 +194,15 @@ namespace SharpPlot
             return true;
         }
         
+        
+        public static (int, TFigure) Plot<TFigure>(IEnumerable<double> x) 
+            where TFigure : Histogram, new()
+        {
+            var fig = new TFigure {ArrX = x.ToArray()};
+            var figId = _getNextId();
+            _figuresDict.Add(figId, fig);
+            return (figId, fig);
+        }
         public static (int, TFigure) Plot<TFigure>(IEnumerable<double> x, IEnumerable<double> y) 
             where TFigure : Figure, new()
         {

--- a/SharpPlot/Gnuplot.cs
+++ b/SharpPlot/Gnuplot.cs
@@ -178,7 +178,12 @@ namespace SharpPlot
 
         public static void SetHidden3D()
         {
-            WriteCommand($"set hidden3d");
+            WriteCommand("set hidden3d");
+        }
+
+        public static void FillSolid()
+        {
+            WriteCommand("set style fill solid");
         }
 
         private static bool _checkCommensurability(IEnumerable<IEnumerable<double>> z)

--- a/SharpPlot/Gnuplot.cs
+++ b/SharpPlot/Gnuplot.cs
@@ -217,7 +217,18 @@ namespace SharpPlot
             where TFigure : Figure, new()
         {
             _checkCommensurability(new [] {x, y, z});
-            var fig = new TFigure {ArrX = x, ArrY = y, ArrZ = z};
+            var fig = new TFigure {ArrX = x, ArrY = y, ArrZ1 = z};
+            var figId = _getNextId();
+            _figuresDict.Add(figId, fig);
+            return (figId, fig);
+        }
+        
+        public static (int, TFigure) Plot<TFigure>(
+            IEnumerable<double> x, IEnumerable<double> y, IEnumerable<double> z1, IEnumerable<double> z2) 
+            where TFigure : Figure, new()
+        {
+            _checkCommensurability(new [] {x, y, z1, z2});
+            var fig = new TFigure {ArrX = x, ArrY = y, ArrZ1 = z1, ArrZ2 = z2};
             var figId = _getNextId();
             _figuresDict.Add(figId, fig);
             return (figId, fig);
@@ -273,7 +284,7 @@ namespace SharpPlot
             var fig = new TFigure {
                 ArrX = x, 
                 ArrY = y,
-                ArrZ = z,
+                ArrZ1 = z,
                 Properties =
                 {
                     Color = color, Marker = marker, 

--- a/SharpPlot/Gnuplot.cs
+++ b/SharpPlot/Gnuplot.cs
@@ -196,7 +196,7 @@ namespace SharpPlot
         
         
         public static (int, TFigure) Plot<TFigure>(IEnumerable<double> x) 
-            where TFigure : Histogram, new()
+            where TFigure : Figure1D, new()
         {
             var fig = new TFigure {ArrX = x.ToArray()};
             var figId = _getNextId();


### PR DESCRIPTION
This pull-request concludes the set of figures available for SharpPlot. These are the new classes included:
* `LinePoints`
* `LinePoints3D`
* `Bars`
* `Histogram`
* `Boxplot`
* `FilledCurves`
* `YError`
* `Vector`