### PR TITLE
Refactor Figure Class to fit new figures requirements

### DIFF
--- a/Examples/001-GettingStarted/README.ipynb
+++ b/Examples/001-GettingStarted/README.ipynb
@@ -57,8 +57,8 @@
    "outputs": [],
    "source": [
     "var x = Enumerable.Range(-100, 201).Select(z=>z*0.025*Math.PI).ToArray();\n",
-    "var sincosX = x.Select(Math.Sin).Select(Math.Cos).ToArray();\n",
-    "var dataSet = new DataSet(x, sincosX);"
+    "var sinX = x.Select(Math.Sin).ToArray();\n",
+    "var data = new DataPoints(x, sincosX);"
    ]
   },
   {
@@ -77,7 +77,7 @@
    "outputs": [],
    "source": [
     "Gnuplot.Start();\n",
-    "Gnuplot.PlotLine2D(dataSet, \"First Example: sin(x)\");\n",
+    "var (id, fig) = Gnuplot.Plot<Line>(data, \"First Example: sin(x)\");\n",
     "Gnuplot.Show();"
    ]
   },

--- a/Examples/001-GettingStarted/README.md
+++ b/Examples/001-GettingStarted/README.md
@@ -38,8 +38,8 @@ namespace GettingStarted
             Gnuplot.Start();
             var x = Enumerable.Range(-100, 201).Select(z=>z*0.025*Math.PI).ToArray();
             var sinX = x.Select(Math.Sin).ToArray();
-            var dataSet = new DataSet(x, sinX);
-            var (id, fig) = Gnuplot.Plot<Line2D>(dataSet, "First Example: sin(x)");
+            var data = new DataPoints(x, sinX);
+            var (id, fig) = Gnuplot.Plot<Line>(data, "First Example: sin(x)");
             Gnuplot.Show();
             Gnuplot.Wait();
         }
@@ -52,7 +52,7 @@ There are several things to understand from this example:
 * We need to import the library with: `using SharpPlot`
 * The initialisation of the `gnuplot` interpreter happens with `Gnuplot.Start()`. This is the default constructor of `SharpPlot.Gnuplot`.
 * In case `SharpPlot.Gnuplot` is not able to initialise or gives any error, try the `explicit` constructor `Gnuplot("{gnuplot/Bin/Path}")`, which allows you to specify where the executable of gnuplot is located at in your computer.
-* `DataSet` is a collection of data, which must be commensurate, i.e. the length of `x` must be equal to the length of `sinX`
-* To represent the data with a line, we use `PlotLine2D`, which accepts the legend of this `DataSet` as second argument.
+* `DataPoints` is a collection of data, which must be commensurate, i.e. the length of `x` must be equal to the length of `sinX`
+* To represent the data with a line, we use `Plot<Line>`, which accepts the legend of this `DataPoints` as second argument.
 
 And this is all for the time being. Congratulations, and see you in the next Example &#128079;

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ namespace graph
             Gnuplot.Start();
             var x = Enumerable.Range(-100, 201).Select(z=>z*0.025*Math.PI).ToArray();
             var sinX = x.Select(Math.Sin).ToArray();
-            var dataSet = new DataSet(x, sinX);
-            var (id, fig) = Gnuplot.Plot<Line2D>(dataSet, "First Example: sin(x)");
+            var data = new DataPoints(x, sinX);
+            var (id, fig) = Gnuplot.Plot<Line>(data, "First Example: sin(x)");
             Gnuplot.Show();
             Gnuplot.Wait();
         }

--- a/SharpPlot.Unittest/Canvas/DataPoints.cs
+++ b/SharpPlot.Unittest/Canvas/DataPoints.cs
@@ -1,10 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MathNet.Numerics;
 using NUnit.Framework;
+using SharpPlot.Canvas;
 
 namespace SharpPlot.UnitTest.Canvas
 {
     [TestFixture]
     public class TestDataPoints
     {
-        //TODO: Add DataPoints tests
+        private DataPoints _dataPoints1D;
+        private DataPoints _dataPoints2D;
+        private DataPoints _dataPoints3D;
+        private DataPoints _dataPoints4D;
+        private List<double> _x = Generate.LinearSpaced(10, 0, 10).ToList();
+        private List<double> _y = Generate.LinearSpaced(10, 0, 10).Select(e => e * 2).ToList();
+        private List<double> _z = Generate.LinearSpaced(10, 0, 10).Select(e => e * 4).ToList();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _dataPoints1D = new DataPoints(x: _x);
+            _dataPoints2D = new DataPoints(x: _x, y: _y);
+            _dataPoints3D = new DataPoints(x: _x, y: _y, z: _z);
+            _dataPoints4D = new DataPoints(x1: _x, x2: _y, y1: _z, y2: _z);
+        }
+
+        [Test]
+        public void Test1DConstructor()
+        {
+            var expectedArray = new double[1][];
+            expectedArray[0] = _x.ToArray();
+            Assert.AreEqual(expectedArray, _dataPoints1D.Array);
+        } 
+        
+        [Test]
+        public void Test2DConstructor()
+        {
+            var expectedArray = new double[2][];
+            expectedArray[0] = _x.ToArray();
+            expectedArray[1] = _y.ToArray();
+            Assert.AreEqual(expectedArray, _dataPoints2D.Array);
+        }
+        
+        [Test]
+        public void Test3DConstructor()
+        {
+            var expectedArray = new double[3][];
+            expectedArray[0] = _x.ToArray();
+            expectedArray[1] = _y.ToArray();
+            expectedArray[2] = _z.ToArray();
+            Assert.AreEqual(expectedArray, _dataPoints3D.Array);
+        }
+        
+        [Test]
+        public void Test4DConstructor()
+        {
+            var expectedArray = new double[4][];
+            expectedArray[0] = _x.ToArray();
+            expectedArray[1] = _y.ToArray();
+            expectedArray[2] = _z.ToArray();
+            expectedArray[3] = _z.ToArray();
+            Assert.AreEqual(expectedArray, _dataPoints4D.Array);
+        } 
+
+        [Test]
+        public void TestDimProperty()
+        {
+            Assert.AreEqual(1, _dataPoints1D.Dim);
+            Assert.AreEqual(2, _dataPoints2D.Dim);
+            Assert.AreEqual(3, _dataPoints3D.Dim);
+            Assert.AreEqual(4, _dataPoints4D.Dim);
+        }
+
+        [Test]
+        public void Test1DStreamPoints()
+        {
+            List<string> expectedStream = new List<string>();
+            expectedStream = _x.Select((e) => $"{e}").ToList();
+            expectedStream.Add("e" + Environment.NewLine);
+            Assert.AreEqual(expectedStream, _dataPoints1D.StreamPoints());
+        }
+        
+        [Test]
+        public void Test2DStreamPoints()
+        {
+            List<string> expectedStream = new List<string>();
+            expectedStream = _x.Select((e, idx) => $"{e} {_y[idx]}").ToList();
+            expectedStream.Add("e" + Environment.NewLine);
+            Assert.AreEqual(expectedStream, _dataPoints2D.StreamPoints());
+        }
+        
+        [Test]
+        public void Test3DStreamPoints()
+        {
+            List<string> expectedStream = new List<string>();
+            expectedStream = _x.Select((e, idx) => $"{e} {_y[idx]} {_z[idx]}").ToList();
+            expectedStream.Add("e" + Environment.NewLine);
+            Assert.AreEqual(expectedStream, _dataPoints3D.StreamPoints());
+        }
+        
+        [Test]
+        public void Test4DStreamPoints()
+        {
+            List<string> expectedStream = new List<string>();
+            expectedStream = _x.Select((e, idx) => $"{e} {_y[idx]} {_z[idx]} {_z[idx]}").ToList();
+            expectedStream.Add("e" + Environment.NewLine);
+            Assert.AreEqual(expectedStream, _dataPoints4D.StreamPoints());
+        }
+
+
     }
 }

--- a/SharpPlot.Unittest/Canvas/DataPoints.cs
+++ b/SharpPlot.Unittest/Canvas/DataPoints.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MathNet.Numerics;
 using NUnit.Framework;
-using SharpPlot.Canvas;
+using SharpPlot.Canvas.Figure;
 
 namespace SharpPlot.UnitTest.Canvas
 {
@@ -74,6 +74,15 @@ namespace SharpPlot.UnitTest.Canvas
             Assert.AreEqual(2, _dataPoints2D.Dim);
             Assert.AreEqual(3, _dataPoints3D.Dim);
             Assert.AreEqual(4, _dataPoints4D.Dim);
+        }
+        
+        [Test]
+        public void TestOptDimProperty()
+        {
+            Assert.AreEqual("1", _dataPoints1D.OptDim);
+            Assert.AreEqual("1:2", _dataPoints2D.OptDim);
+            Assert.AreEqual("1:2:3", _dataPoints3D.OptDim);
+            Assert.AreEqual("1:2:3:4", _dataPoints4D.OptDim);
         }
 
         [Test]

--- a/SharpPlot.Unittest/Canvas/DataPoints.cs
+++ b/SharpPlot.Unittest/Canvas/DataPoints.cs
@@ -15,8 +15,10 @@ namespace SharpPlot.UnitTest.Canvas
         private DataPoints _dataPoints3D;
         private DataPoints _dataPoints4D;
         private List<double> _x = Generate.LinearSpaced(10, 0, 10).ToList();
+        private List<double> _xWrongSize = Generate.LinearSpaced(20, 0, 10).ToList();
         private List<double> _y = Generate.LinearSpaced(10, 0, 10).Select(e => e * 2).ToList();
         private List<double> _z = Generate.LinearSpaced(10, 0, 10).Select(e => e * 4).ToList();
+        
 
         [SetUp]
         public void SetUp()
@@ -108,6 +110,12 @@ namespace SharpPlot.UnitTest.Canvas
             expectedStream = _x.Select((e, idx) => $"{e} {_y[idx]} {_z[idx]} {_z[idx]}").ToList();
             expectedStream.Add("e" + Environment.NewLine);
             Assert.AreEqual(expectedStream, _dataPoints4D.StreamPoints());
+        }
+
+        [Test]
+        public void TestCheckCommensurability()
+        {
+            Assert.Throws<ApplicationException>(() => new DataPoints(x: _x, y: _xWrongSize));
         }
 
 

--- a/SharpPlot.Unittest/Canvas/DataPoints.cs
+++ b/SharpPlot.Unittest/Canvas/DataPoints.cs
@@ -1,0 +1,10 @@
+using NUnit.Framework;
+
+namespace SharpPlot.UnitTest.Canvas
+{
+    [TestFixture]
+    public class TestDataPoints
+    {
+        //TODO: Add DataPoints tests
+    }
+}

--- a/SharpPlot.Unittest/Canvas/Figure.cs
+++ b/SharpPlot.Unittest/Canvas/Figure.cs
@@ -97,7 +97,7 @@ namespace SharpPlot.UnitTest.Canvas
             var expectedDataPoints = _x.Select((t, idx) => $"{t} {_y[idx]}").ToList();
             expectedDataPoints.Add("e" + Environment.NewLine);
             Assert.AreEqual("", _figure.Options);
-            Assert.AreEqual(" '-'  title '' ",_figure.HeaderPlot);
+            Assert.AreEqual(" '-' title ''",_figure.HeaderPlot);
             Assert.AreEqual( expectedDataPoints, _figure.DataPoints);
         }
 
@@ -152,24 +152,24 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestScatter2D()
         {
-            var expectedOps = $"u 1:2 with points ps {_scatter2D.Properties.Size} pt {(int) _scatter2D.Properties.Marker} " +
-                              $"lc rgb '{_scatter2D.Properties.Color.ToString().ToLower()}'";
+            var expectedOps = $"u 1:2 with points {_scatter2D.Properties.OptSize} {_scatter2D.Properties.OptMarker} " +
+                              $"{_scatter2D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _scatter2D.Options);
         }
 
         [Test]
         public void TestLine2D()
         {
-            var expectedOps = $"u 1:2 with lines lw {_line2D.Properties.Width} dt {(int) _line2D.Properties.DashType} " +
-                              $"lc rgb '{_line2D.Properties.Color.ToString().ToLower()}'";
+            var expectedOps = $"u 1:2 with lines {_line2D.Properties.OptWidth} {_line2D.Properties.OptDashType} " +
+                              $"{_line2D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _line2D.Options);
         }
 
         [Test]
         public void TestFilledCurves()
         {
-            var expectedOps = $"u 1:2:3 with filledcurve lw {_filledCurves.Properties.Width} " +
-                              $"dt {(int) _filledCurves.Properties.DashType} lc rgb '{_filledCurves.Properties.Color.ToString().ToLower()}'";
+            var expectedOps = $"u 1:2:3 with filledcurve {_filledCurves.Properties.OptWidth} " +
+                              $"{_filledCurves.Properties.OptDashType} {_filledCurves.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _filledCurves.Options);
             
             var expectedDataPoints = _x.Select((t, idx) => $"{t} {_y[idx]} {_z[idx]}").ToList();
@@ -180,17 +180,17 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestLinePoints2D()
         {
-            var expectedOps = $"u 1:2 with linespoints lw {_linePoints2D.Properties.Width} dt {(int) _linePoints2D.Properties.DashType} " +
-                              $"ps {_linePoints2D.Properties.Size} pt {(int) _linePoints2D.Properties.Marker} " +
-                              $"lc rgb '{_linePoints2D.Properties.Color.ToString().ToLower()}'";
+            var expectedOps = $"u 1:2 with linespoints {_linePoints2D.Properties.OptWidth} {_linePoints2D.Properties.OptDashType} " +
+                              $"{_linePoints2D.Properties.OptSize} {_linePoints2D.Properties.OptMarker} " +
+                              $"{_linePoints2D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _linePoints2D.Options);
         }
 
         [Test]
         public void TestYErr()
         {
-            var expectedOps = $"u 1:2:3 with yerr ps {_yError.Properties.Size} pt {(int) _yError.Properties.Marker} " +
-                              $"lc rgb '{_yError.Properties.Color.ToString().ToLower()}'";
+            var expectedOps = $"u 1:2:3 with yerr {_yError.Properties.OptSize} {_yError.Properties.OptMarker} " +
+                              $"{_yError.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _yError.Options);
             
             var expectedDataPoints = _x.Select((t, idx) => $"{t} {_y[idx]} {_z[idx]}").ToList();
@@ -203,8 +203,8 @@ namespace SharpPlot.UnitTest.Canvas
         {
             Assert.AreEqual(PlotType.Splot, _scatter3D.PlotType);
             
-            var expectedOps = $"u 1:2:3 with points ps {_scatter3D.Properties.Size} pt {(int) _scatter3D.Properties.Marker} " +
-                              $"lc rgb '{_scatter3D.Properties.Color.ToString().ToLower()}'";
+            var expectedOps = $"u 1:2:3 with points {_scatter3D.Properties.OptSize} {_scatter3D.Properties.OptMarker} " +
+                              $"{_scatter3D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _scatter3D.Options);
             
             var expectedDataPoints = _x.Select((t, idx) => $"{t} {_y[idx]} {_z[idx]}").ToList();
@@ -217,25 +217,25 @@ namespace SharpPlot.UnitTest.Canvas
         {
             Assert.AreEqual(PlotType.Splot, _line3D.PlotType);
             
-            var expectedOps = $"u 1:2:3 with lines lw {_line3D.Properties.Width} dt {(int) _line3D.Properties.DashType} " +
-                              $"lc rgb '{_line3D.Properties.Color.ToString().ToLower()}'";
+            var expectedOps = $"u 1:2:3 with lines {_line3D.Properties.OptWidth} {_line3D.Properties.OptDashType} " +
+                              $"{_line3D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _line3D.Options);
         }
 
         [Test]
         public void TestLinePoints3D()
         {
-            var expectedOps = $"u 1:2:3 with linespoints lw {_linePoints3D.Properties.Width} dt {(int) _linePoints3D.Properties.DashType} " +
-                              $"ps {_linePoints3D.Properties.Size} pt {(int) _linePoints3D.Properties.Marker} " +
-                              $"lc rgb '{_linePoints3D.Properties.Color.ToString().ToLower()}'";
+            var expectedOps = $"u 1:2:3 with linespoints {_linePoints3D.Properties.OptWidth} {_linePoints3D.Properties.OptDashType} " +
+                              $"{_linePoints3D.Properties.OptSize} {_linePoints3D.Properties.OptMarker} " +
+                              $"{_linePoints3D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _linePoints3D.Options);
         }
 
         [Test]
         public void TestImpulse()
         {
-            var expectedOps = $"u 1:2 with impulses lw {_impulse.Properties.Width} dt {(int) _impulse.Properties.DashType} " +
-                              $"lc rgb '{_impulse.Properties.Color.ToString().ToLower()}'";
+            var expectedOps = $"u 1:2 with impulses {_impulse.Properties.OptWidth} {_impulse.Properties.OptDashType} " +
+                              $"{_impulse.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _impulse.Options);
         }
 
@@ -246,14 +246,14 @@ namespace SharpPlot.UnitTest.Canvas
             Assert.AreEqual("", _function.PlotInit);
             Assert.AreEqual(new List<string>(), _function.DataPoints);
             
-            var expectedOps = $" {_function.Properties.Function} lc rgb '{_function.Properties.Color.ToString().ToLower()}'";
+            var expectedOps = $" {_function.Properties.Function} {_function.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _function.Options);
         }
 
         [Test]
         public void TestBars()
         {
-            var expectedOps = $"u 1:2:({_bars.Properties.Width}) with boxes lc rgb '{_bars.Properties.Color.ToString().ToLower()}'";
+            var expectedOps = $"u 1:2:({_bars.Properties.Width}) with boxes {_bars.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _bars.Options);
         }
 
@@ -261,7 +261,7 @@ namespace SharpPlot.UnitTest.Canvas
         public void TestHistogram()
         {
             var expectedOps = $"u 1:({_histogram.Properties.Width}) smooth freq with boxes " +
-                              $"lc rgb '{_histogram.Properties.Color.ToString().ToLower()}'";
+                              $"{_histogram.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _histogram.Options);
 
             var x = _histogram.ArrX;
@@ -275,8 +275,8 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestBoxplot()
         {
-            var expectedOps = $"u (0.0):1:({_boxplot.Properties.Width}) pt {(int) _boxplot.Properties.Marker} " +
-                             $"lc rgb '{_boxplot.Properties.Color.ToString().ToLower()}'";
+            var expectedOps = $"u (0.0):1:({_boxplot.Properties.Width}) {_boxplot.Properties.OptMarker} " +
+                             $"{_boxplot.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _boxplot.Options);
             
             var expectedDataPoints = _histogram.ArrX.Select(t => $"{t}").ToList();
@@ -287,8 +287,8 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestVector()
         {
-            var expectedOps = $"u 1:2:3:4 with vector lw {_vector.Properties.Width} " +
-                              $"lc rgb '{_vector.Properties.Color.ToString().ToLower()}'";
+            var expectedOps = $"u 1:2:3:4 with vector {_vector.Properties.OptWidth} " +
+                              $"{_vector.Properties.OptColor}";
             
             Assert.AreEqual(expectedOps, _vector.Options);
             

--- a/SharpPlot.Unittest/Canvas/Figure.cs
+++ b/SharpPlot.Unittest/Canvas/Figure.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using MathNet.Numerics;
 using MathNet.Numerics.Distributions;
 using NUnit.Framework;
+using SharpPlot.Canvas;
 using SharpPlot.Canvas.Figure;
 using SharpPlot.Utils;
 
@@ -38,22 +39,22 @@ namespace SharpPlot.UnitTest.Canvas
         {
             _figure = new Figure()
             {
-                ArrX = _x, ArrY = _y
+                Data = new DataPoints(x: _x, y: _y) 
             };
             _scatter2D = new Scatter2D();
             _scatter3D = new Scatter3D()
             {
-                ArrX = _x, ArrY = _y, ArrZ1 = _z
+                Data = new DataPoints(x: _x, y: _y, z: _z) 
             };
             _line2D = new Line2D();
             _filledCurves = new FilledCurves()
             {
-                ArrX = _x, ArrY = _y, ArrZ1 = _z
+                Data = new DataPoints(x: _x, y: _y, z: _z) 
             };
             _linePoints2D = new LinePoints2D();
             _yError = new YError()
             {
-                ArrX = _x, ArrY = _y, ArrZ1 = _z
+                Data = new DataPoints(x: _x, y: _y, z: _z) 
             };
             _line3D = new Line3D();
             _linePoints3D = new LinePoints3D();
@@ -66,15 +67,15 @@ namespace SharpPlot.UnitTest.Canvas
             Normal.Samples(_array, mean: 0, stddev: 1);
             _histogram = new Histogram()
             {
-                ArrX = _array
+                Data = new DataPoints(x: _array) 
             };
             _boxplot = new Boxplot()
             {
-                ArrX = _array
+                Data = new DataPoints(x: _array)
             };
             _vector = new Vector()
             {
-                ArrX = _x, ArrY = _y, ArrZ1 = _z, ArrZ2 = _z
+                Data = new DataPoints(x1: _x, x2: _y, y1: _z, y2: _z) 
             };
             
         }
@@ -264,7 +265,7 @@ namespace SharpPlot.UnitTest.Canvas
                               $"{_histogram.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _histogram.Options);
 
-            var x = _histogram.ArrX;
+            var x = _histogram.Data.Array[0];
             var bins = Math.Min(Math.Ceiling(Math.Sqrt(x.Count())), 100.0);
             var width = (x.Max() - x.Min()) / bins;
             var expectedDataPoints = x.Select(e => $"{width * Math.Floor(e / width) + width / 2.0}").ToList();
@@ -279,7 +280,7 @@ namespace SharpPlot.UnitTest.Canvas
                              $"{_boxplot.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _boxplot.Options);
             
-            var expectedDataPoints = _histogram.ArrX.Select(t => $"{t}").ToList();
+            var expectedDataPoints = _histogram.Data.Array[0].Select(t => $"{t}").ToList();
             expectedDataPoints.Add("e" + Environment.NewLine);
             Assert.AreEqual(expectedDataPoints, _boxplot.DataPoints);
         }

--- a/SharpPlot.Unittest/Canvas/Figure.cs
+++ b/SharpPlot.Unittest/Canvas/Figure.cs
@@ -97,7 +97,7 @@ namespace SharpPlot.UnitTest.Canvas
             var expectedDataPoints = _x.Select((t, idx) => $"{t} {_y[idx]}").ToList();
             expectedDataPoints.Add("e" + Environment.NewLine);
             Assert.AreEqual("", _figure.Options);
-            Assert.AreEqual(" '-' title ''",_figure.HeaderPlot);
+            Assert.AreEqual(" '-'  title ''",_figure.HeaderPlot);
             Assert.AreEqual( expectedDataPoints, _figure.DataPoints);
         }
 
@@ -152,7 +152,7 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestScatter2D()
         {
-            var expectedOps = $"u 1:2 with points {_scatter2D.Properties.OptSize} {_scatter2D.Properties.OptMarker} " +
+            var expectedOps = $"u 1:2 {Shape.Points} {_scatter2D.Properties.OptSize} {_scatter2D.Properties.OptMarker} " +
                               $"{_scatter2D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _scatter2D.Options);
         }
@@ -160,7 +160,7 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestLine2D()
         {
-            var expectedOps = $"u 1:2 with lines {_line2D.Properties.OptWidth} {_line2D.Properties.OptDashType} " +
+            var expectedOps = $"u 1:2 {Shape.Lines} {_line2D.Properties.OptWidth} {_line2D.Properties.OptDashType} " +
                               $"{_line2D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _line2D.Options);
         }
@@ -168,7 +168,7 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestFilledCurves()
         {
-            var expectedOps = $"u 1:2:3 with filledcurve {_filledCurves.Properties.OptWidth} " +
+            var expectedOps = $"u 1:2:3 {Shape.FilledCurve} {_filledCurves.Properties.OptWidth} " +
                               $"{_filledCurves.Properties.OptDashType} {_filledCurves.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _filledCurves.Options);
             
@@ -180,7 +180,7 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestLinePoints2D()
         {
-            var expectedOps = $"u 1:2 with linespoints {_linePoints2D.Properties.OptWidth} {_linePoints2D.Properties.OptDashType} " +
+            var expectedOps = $"u 1:2 {Shape.LinesPoints} {_linePoints2D.Properties.OptWidth} {_linePoints2D.Properties.OptDashType} " +
                               $"{_linePoints2D.Properties.OptSize} {_linePoints2D.Properties.OptMarker} " +
                               $"{_linePoints2D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _linePoints2D.Options);
@@ -189,7 +189,7 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestYErr()
         {
-            var expectedOps = $"u 1:2:3 with yerr {_yError.Properties.OptSize} {_yError.Properties.OptMarker} " +
+            var expectedOps = $"u 1:2:3 {Shape.YErr} {_yError.Properties.OptSize} {_yError.Properties.OptMarker} " +
                               $"{_yError.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _yError.Options);
             
@@ -203,7 +203,7 @@ namespace SharpPlot.UnitTest.Canvas
         {
             Assert.AreEqual(PlotType.Splot, _scatter3D.PlotType);
             
-            var expectedOps = $"u 1:2:3 with points {_scatter3D.Properties.OptSize} {_scatter3D.Properties.OptMarker} " +
+            var expectedOps = $"u 1:2:3 {Shape.Points} {_scatter3D.Properties.OptSize} {_scatter3D.Properties.OptMarker} " +
                               $"{_scatter3D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _scatter3D.Options);
             
@@ -217,7 +217,7 @@ namespace SharpPlot.UnitTest.Canvas
         {
             Assert.AreEqual(PlotType.Splot, _line3D.PlotType);
             
-            var expectedOps = $"u 1:2:3 with lines {_line3D.Properties.OptWidth} {_line3D.Properties.OptDashType} " +
+            var expectedOps = $"u 1:2:3 {Shape.Lines} {_line3D.Properties.OptWidth} {_line3D.Properties.OptDashType} " +
                               $"{_line3D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _line3D.Options);
         }
@@ -225,7 +225,7 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestLinePoints3D()
         {
-            var expectedOps = $"u 1:2:3 with linespoints {_linePoints3D.Properties.OptWidth} {_linePoints3D.Properties.OptDashType} " +
+            var expectedOps = $"u 1:2:3 {Shape.LinesPoints} {_linePoints3D.Properties.OptWidth} {_linePoints3D.Properties.OptDashType} " +
                               $"{_linePoints3D.Properties.OptSize} {_linePoints3D.Properties.OptMarker} " +
                               $"{_linePoints3D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _linePoints3D.Options);
@@ -234,7 +234,7 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestImpulse()
         {
-            var expectedOps = $"u 1:2 with impulses {_impulse.Properties.OptWidth} {_impulse.Properties.OptDashType} " +
+            var expectedOps = $"u 1:2 {Shape.Impulses} {_impulse.Properties.OptWidth} {_impulse.Properties.OptDashType} " +
                               $"{_impulse.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _impulse.Options);
         }
@@ -253,14 +253,14 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestBars()
         {
-            var expectedOps = $"u 1:2:({_bars.Properties.Width}) with boxes {_bars.Properties.OptColor}";
+            var expectedOps = $"u 1:2:({_bars.Properties.Width}) {Shape.Boxes} {_bars.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _bars.Options);
         }
 
         [Test]
         public void TestHistogram()
         {
-            var expectedOps = $"u 1:({_histogram.Properties.Width}) smooth freq with boxes " +
+            var expectedOps = $"u 1:({_histogram.Properties.Width}) smooth freq {Shape.Boxes} " +
                               $"{_histogram.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _histogram.Options);
 
@@ -287,7 +287,7 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestVector()
         {
-            var expectedOps = $"u 1:2:3:4 with vector {_vector.Properties.OptWidth} " +
+            var expectedOps = $"u 1:2:3:4 {Shape.Vector} {_vector.Properties.OptWidth} " +
                               $"{_vector.Properties.OptColor}";
             
             Assert.AreEqual(expectedOps, _vector.Options);

--- a/SharpPlot.Unittest/Canvas/Figure.cs
+++ b/SharpPlot.Unittest/Canvas/Figure.cs
@@ -14,14 +14,14 @@ namespace SharpPlot.UnitTest.Canvas
     public class TestFigure
     {
         private Figure _figure;
-        private Scatter2D _scatter2D;
-        private Scatter3D _scatter3D;
-        private Line2D _line2D;
+        private Scatter _scatter2D;
+        private Scatter _scatter3D;
+        private Line _line2D;
         private FilledCurves _filledCurves;
-        private LinePoints2D _linePoints2D;
+        private LinePoints _linePoints2D;
         private YError _yError;
-        private Line3D _line3D;
-        private LinePoints3D _linePoints3D;
+        private Line _line3D;
+        private LinePoints _linePoints3D;
         private Impulse _impulse;
         private Function _function;
         private Bars _bars;
@@ -41,23 +41,38 @@ namespace SharpPlot.UnitTest.Canvas
             {
                 Data = new DataPoints(x: _x, y: _y) 
             };
-            _scatter2D = new Scatter2D();
-            _scatter3D = new Scatter3D()
+            _scatter2D = new Scatter()
+            {
+                Data = new DataPoints(x: _x, y: _y)
+            };
+            _scatter3D = new Scatter()
             {
                 Data = new DataPoints(x: _x, y: _y, z: _z) 
             };
-            _line2D = new Line2D();
+            _line2D = new Line()
+            {
+                Data = new DataPoints(x: _x, y: _y)
+            };
             _filledCurves = new FilledCurves()
             {
                 Data = new DataPoints(x: _x, y: _y, z: _z) 
             };
-            _linePoints2D = new LinePoints2D();
+            _linePoints2D = new LinePoints()
+            {
+                Data = new DataPoints(x: _x, y: _y)
+            };
             _yError = new YError()
             {
                 Data = new DataPoints(x: _x, y: _y, z: _z) 
             };
-            _line3D = new Line3D();
-            _linePoints3D = new LinePoints3D();
+            _line3D = new Line()
+            {
+                Data = new DataPoints(x: _x, y: _y, z: _z)
+            };
+            _linePoints3D = new LinePoints()
+            {
+                Data = new DataPoints(x: _x, y: _y, z: _z) 
+            };
             _impulse = new Impulse();
             _function = new Function()
             {
@@ -153,16 +168,16 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestScatter2D()
         {
-            var expectedOps = $"u 1:2 {Shape.Points} {_scatter2D.Properties.OptSize} {_scatter2D.Properties.OptMarker} " +
-                              $"{_scatter2D.Properties.OptColor}";
+            var expectedOps = $"u {_scatter2D.Data.OptDim} {Shape.Points} {_scatter2D.Properties.OptSize} " +
+                              $"{_scatter2D.Properties.OptMarker} {_scatter2D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _scatter2D.Options);
         }
 
         [Test]
         public void TestLine2D()
         {
-            var expectedOps = $"u 1:2 {Shape.Lines} {_line2D.Properties.OptWidth} {_line2D.Properties.OptDashType} " +
-                              $"{_line2D.Properties.OptColor}";
+            var expectedOps = $"u {_line2D.Data.OptDim} {Shape.Lines} {_line2D.Properties.OptWidth} " +
+                              $"{_line2D.Properties.OptDashType} {_line2D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _line2D.Options);
         }
 
@@ -181,9 +196,9 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestLinePoints2D()
         {
-            var expectedOps = $"u 1:2 {Shape.LinesPoints} {_linePoints2D.Properties.OptWidth} {_linePoints2D.Properties.OptDashType} " +
-                              $"{_linePoints2D.Properties.OptSize} {_linePoints2D.Properties.OptMarker} " +
-                              $"{_linePoints2D.Properties.OptColor}";
+            var expectedOps = $"u {_linePoints2D.Data.OptDim} {Shape.LinesPoints} {_linePoints2D.Properties.OptWidth} " +
+                              $"{_linePoints2D.Properties.OptDashType} {_linePoints2D.Properties.OptSize} " +
+                              $"{_linePoints2D.Properties.OptMarker} {_linePoints2D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _linePoints2D.Options);
         }
 
@@ -202,10 +217,8 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestScatter3D()
         {
-            Assert.AreEqual(PlotType.Splot, _scatter3D.PlotType);
-            
-            var expectedOps = $"u 1:2:3 {Shape.Points} {_scatter3D.Properties.OptSize} {_scatter3D.Properties.OptMarker} " +
-                              $"{_scatter3D.Properties.OptColor}";
+            var expectedOps = $"u {_scatter3D.Data.OptDim} {Shape.Points} {_scatter3D.Properties.OptSize} " +
+                              $"{_scatter3D.Properties.OptMarker} {_scatter3D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _scatter3D.Options);
             
             var expectedDataPoints = _x.Select((t, idx) => $"{t} {_y[idx]} {_z[idx]}").ToList();
@@ -216,17 +229,15 @@ namespace SharpPlot.UnitTest.Canvas
         [Test]
         public void TestLine3D()
         {
-            Assert.AreEqual(PlotType.Splot, _line3D.PlotType);
-            
-            var expectedOps = $"u 1:2:3 {Shape.Lines} {_line3D.Properties.OptWidth} {_line3D.Properties.OptDashType} " +
-                              $"{_line3D.Properties.OptColor}";
+            var expectedOps = $"u {_line3D.Data.OptDim} {Shape.Lines} {_line3D.Properties.OptWidth} " +
+                              $"{_line3D.Properties.OptDashType} {_line3D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _line3D.Options);
         }
 
         [Test]
         public void TestLinePoints3D()
         {
-            var expectedOps = $"u 1:2:3 {Shape.LinesPoints} {_linePoints3D.Properties.OptWidth} {_linePoints3D.Properties.OptDashType} " +
+            var expectedOps = $"u {_line3D.Data.OptDim} {Shape.LinesPoints} {_linePoints3D.Properties.OptWidth} {_linePoints3D.Properties.OptDashType} " +
                               $"{_linePoints3D.Properties.OptSize} {_linePoints3D.Properties.OptMarker} " +
                               $"{_linePoints3D.Properties.OptColor}";
             Assert.AreEqual(expectedOps, _linePoints3D.Options);

--- a/SharpPlot.Unittest/Canvas/FigureProperties.cs
+++ b/SharpPlot.Unittest/Canvas/FigureProperties.cs
@@ -1,0 +1,66 @@
+using NUnit.Framework;
+using SharpPlot.Canvas.Figure;
+using SharpPlot.Utils;
+
+namespace SharpPlot.UnitTest.Canvas
+{
+    [TestFixture]
+    public class TestFigureProperties
+    {
+        private FigureProperties _properties;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _properties = new FigureProperties();
+        }
+        
+        [Test]
+        public void TestDefaultProperties()
+        {
+            Assert.AreEqual(1, _properties.Size);
+            Assert.AreEqual(Color.Black, _properties.Color);
+            Assert.AreEqual(DashType.Solid, _properties.DashType);
+            Assert.AreEqual(Marker.ColoredCircle, _properties.Marker);
+            Assert.AreEqual(1, _properties.Width);
+            Assert.AreEqual("", _properties.Function);
+            Assert.AreEqual("", _properties.Title);
+        }
+
+        [Test]
+        public void TestOptSize()
+        {
+            Assert.AreEqual($"ps {_properties.Size}", _properties.OptSize);
+        }
+        
+        [Test]
+        public void TestOptColor()
+        {
+            Assert.AreEqual($"lc rgb '{_properties.Color.ToString().ToLower()}'", _properties.OptColor);
+        }
+        
+        [Test]
+        public void TestOptDashType()
+        {
+            Assert.AreEqual($"dt {(int) _properties.DashType}", _properties.OptDashType);
+        }
+        
+        [Test]
+        public void TestOptMarker()
+        {
+            Assert.AreEqual($"pt {(int) _properties.Marker}", _properties.OptMarker);
+        }
+        
+        [Test]
+        public void TestOptWidth()
+        {
+            Assert.AreEqual($"lw {_properties.Width}", _properties.OptWidth);
+        }
+
+        [Test]
+        public void TestOptTitle()
+        {
+            Assert.AreEqual($"title '{_properties.Title}'", _properties.OptTitle);
+        }
+    }
+}

--- a/SharpPlot.Unittest/Canvas/Shape.cs
+++ b/SharpPlot.Unittest/Canvas/Shape.cs
@@ -1,0 +1,57 @@
+using NUnit.Framework;
+using SharpPlot.Canvas.Figure;
+
+namespace SharpPlot.UnitTest.Canvas
+{
+    [TestFixture]
+    public class TestShape
+    {
+        [Test]
+        public void TestPoints()
+        {
+            Assert.AreEqual("with points", Shape.Points);
+        }
+
+        [Test]
+        public void TestLines()
+        {
+            Assert.AreEqual("with lines", Shape.Lines);
+        }
+
+        [Test]
+        public void TestFilledCurves()
+        {
+            Assert.AreEqual("with filledcurve", Shape.FilledCurve);
+        }
+
+        [Test]
+        public void TestLinesPoints()
+        {
+            Assert.AreEqual("with linespoints", Shape.LinesPoints);
+        }
+
+        [Test]
+        public void TestYErr()
+        {
+            Assert.AreEqual("with yerr", Shape.YErr);
+        }
+
+        [Test]
+        public void TestImpulses()
+        {
+            Assert.AreEqual("with impulses", Shape.Impulses);
+        }
+
+        [Test]
+        public void TestBoxes()
+        {
+            Assert.AreEqual("with boxes", Shape.Boxes);
+        }
+
+        [Test]
+        public void TestVector()
+        {
+            Assert.AreEqual("with vector", Shape.Vector);
+        }
+    }
+}

--- a/SharpPlot/Canvas/DataPoints.cs
+++ b/SharpPlot/Canvas/DataPoints.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SharpPlot.Canvas
+{
+    public class DataPoints
+    {
+        protected internal double[][] Array;
+        public int Dim => Array.Length;
+
+        #region Constructors
+        //TODO: Implement _checkCommensurability
+        public DataPoints(IEnumerable<double> x)
+        {
+            Array  = new double[1][];
+            Array[0] = x.ToArray();
+        }
+
+        public DataPoints(IEnumerable<double> x, IEnumerable<double> y)
+        {
+            Array = new double[2][];
+            Array[0] = x.ToArray();
+            Array[1] = y.ToArray();
+        }
+
+        public DataPoints(IEnumerable<double> x, IEnumerable<double> y, IEnumerable<double> z)
+        {
+            Array = new double[3][];
+            Array[0] = x.ToArray();
+            Array[1] = y.ToArray();
+            Array[2] = z.ToArray();
+        }
+
+        public DataPoints(IEnumerable<double> x1, IEnumerable<double> x2, IEnumerable<double> y1, IEnumerable<double> y2)
+        {
+            Array = new double[4][];
+            Array[0] = x1.ToArray();
+            Array[1] = x2.ToArray();
+            Array[2] = y1.ToArray();
+            Array[3] = y2.ToArray();
+        }
+        #endregion
+
+        #region Methods
+
+        internal List<string> StreamPoints()
+        {
+            List<string> commands = new List<string>();
+            switch (Dim)
+            {
+                case 1:
+                    commands = Array[0].Select((e) => $"{e}").ToList();
+                    break;
+                
+                case 2:
+                    commands = Array[0].Select((e, idx) => $"{e} {Array[1][idx]}").ToList();
+                    break;
+                
+                case 3:
+                    commands = Array[0].Select((e, idx) => $"{e} {Array[1][idx]} {Array[2][idx]}").ToList();
+                    break;
+                
+                case 4:
+                    commands = Array[0].Select((e, idx) => $"{e} {Array[1][idx]} {Array[2][idx]} {Array[3][idx]}").ToList();
+                    break;
+            }
+
+            commands.Add("e" + Environment.NewLine);
+
+            return commands;
+        }
+
+        #endregion
+
+    }
+}

--- a/SharpPlot/Canvas/DataPoints.cs
+++ b/SharpPlot/Canvas/DataPoints.cs
@@ -10,7 +10,6 @@ namespace SharpPlot.Canvas
         public int Dim => Array.Length;
 
         #region Constructors
-        //TODO: Implement _checkCommensurability
         public DataPoints(IEnumerable<double> x)
         {
             Array  = new double[1][];
@@ -22,6 +21,7 @@ namespace SharpPlot.Canvas
             Array = new double[2][];
             Array[0] = x.ToArray();
             Array[1] = y.ToArray();
+            _checkCommensurability();
         }
 
         public DataPoints(IEnumerable<double> x, IEnumerable<double> y, IEnumerable<double> z)
@@ -30,6 +30,7 @@ namespace SharpPlot.Canvas
             Array[0] = x.ToArray();
             Array[1] = y.ToArray();
             Array[2] = z.ToArray();
+            _checkCommensurability();
         }
 
         public DataPoints(IEnumerable<double> x1, IEnumerable<double> x2, IEnumerable<double> y1, IEnumerable<double> y2)
@@ -39,10 +40,18 @@ namespace SharpPlot.Canvas
             Array[1] = x2.ToArray();
             Array[2] = y1.ToArray();
             Array[3] = y2.ToArray();
+            _checkCommensurability();
         }
         #endregion
 
         #region Methods
+
+        private void _checkCommensurability()
+        {
+            var lengths = Array.Select(e => e.Length).ToList();
+            var commensurate = lengths.Aggregate(true, (current, t) => (current && (t == lengths.First())));
+            if (!commensurate) {throw new ApplicationException($"[!] Shape: {string.Join(", ", lengths)}");}
+        }
 
         internal List<string> StreamPoints()
         {

--- a/SharpPlot/Canvas/Figure/DataPoints.cs
+++ b/SharpPlot/Canvas/Figure/DataPoints.cs
@@ -2,12 +2,17 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SharpPlot.Canvas
+namespace SharpPlot.Canvas.Figure
 {
     public class DataPoints
     {
         protected internal double[][] Array;
+
+        #region Properties
         public int Dim => Array.Length;
+        public string OptDim => _getOptDim();
+        #endregion
+
 
         #region Constructors
         public DataPoints(IEnumerable<double> x)
@@ -51,6 +56,17 @@ namespace SharpPlot.Canvas
             var lengths = Array.Select(e => e.Length).ToList();
             var commensurate = lengths.Aggregate(true, (current, t) => (current && (t == lengths.First())));
             if (!commensurate) {throw new ApplicationException($"[!] Shape: {string.Join(", ", lengths)}");}
+        }
+
+        private string _getOptDim()
+        {
+            var optDim = "1";
+            foreach (var dim in Enumerable.Range(2, Dim-1))
+            {
+                optDim += $":{dim}";
+            }
+
+            return optDim;
         }
 
         internal List<string> StreamPoints()

--- a/SharpPlot/Canvas/Figure/Figure.cs
+++ b/SharpPlot/Canvas/Figure/Figure.cs
@@ -40,7 +40,7 @@ namespace SharpPlot.Canvas.Figure
 
         private string _getHeaderPlot()
         {
-            return PlotInit + Options + $" title '{Properties.Title}' ";
+            return PlotInit + Options + Properties.OptTitle;
         }
 
         protected virtual string _getOptions()
@@ -129,7 +129,7 @@ namespace SharpPlot.Canvas.Figure
         #region Methods
         protected override string _getOptions()
         {
-            return $"u 1:2 with points ps {Properties.Size} pt {(int) Properties.Marker} lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $"u 1:2 with points {Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
         }
         #endregion
 
@@ -140,7 +140,7 @@ namespace SharpPlot.Canvas.Figure
         #region Methods
         protected override string _getOptions()
         {
-            return $"u 1:2 with lines lw {Properties.Width} dt {(int) Properties.DashType} lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $"u 1:2 with lines {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
         }
         #endregion
 
@@ -158,7 +158,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2:3 with filledcurve lw {Properties.Width} dt {(int) Properties.DashType} lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $"u 1:2:3 with filledcurve {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
         }
 
         private List<string> _getDataPoints()
@@ -181,8 +181,8 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2 with linespoints lw {Properties.Width} dt {(int) Properties.DashType} " +
-                   $"ps {Properties.Size} pt {(int) Properties.Marker} lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $"u 1:2 with linespoints {Properties.OptWidth} {Properties.OptDashType} " +
+                   $"{Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
         }
 
         #endregion
@@ -199,7 +199,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2:3 with yerr ps {Properties.Size} pt {(int) Properties.Marker} lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $"u 1:2:3 with yerr {Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
         }
         
         private List<string> _getDataPoints()
@@ -225,7 +225,7 @@ namespace SharpPlot.Canvas.Figure
         #region Methods
         protected override string _getOptions()
         {
-            return $"u 1:2:3 with points ps {Properties.Size} pt {(int) Properties.Marker} lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $"u 1:2:3 with points {Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
         }
         #endregion
     }
@@ -240,7 +240,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2:3 with lines lw {Properties.Width} dt {(int) Properties.DashType} lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $"u 1:2:3 with lines {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
         }
 
         #endregion
@@ -256,8 +256,8 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2:3 with linespoints lw {Properties.Width} dt {(int) Properties.DashType} " +
-                   $"ps {Properties.Size} pt {(int) Properties.Marker} lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $"u 1:2:3 with linespoints {Properties.OptWidth} {Properties.OptDashType} " +
+                   $"{Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
         }
 
         #endregion
@@ -276,7 +276,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $" {Properties.Function} lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $" {Properties.Function} {Properties.OptColor}";
         }
 
         #endregion
@@ -290,7 +290,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2 with impulses lw {Properties.Width} dt {(int) Properties.DashType} lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $"u 1:2 with impulses {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
         }
 
         #endregion
@@ -302,7 +302,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2:({Properties.Width}) with boxes lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $"u 1:2:({Properties.Width}) with boxes {Properties.OptColor}";
         }
         
         #endregion
@@ -321,7 +321,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:({Properties.Width}) smooth freq with boxes lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $"u 1:({Properties.Width}) smooth freq with boxes {Properties.OptColor}";
         }
 
         private IEnumerable<double> _preparePoints()
@@ -368,7 +368,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u (0.0):1:({Properties.Width}) pt {(int) Properties.Marker} lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $"u (0.0):1:({Properties.Width}) {Properties.OptMarker} {Properties.OptColor}";
         }
 
         private List<string> _getBoxplotPoints()
@@ -396,7 +396,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2:3:4 with vector lw {Properties.Width} lc rgb '{Properties.Color.ToString().ToLower()}'";
+            return $"u 1:2:3:4 with vector {Properties.OptWidth} {Properties.OptColor}";
         }
 
         private List<string> _getVectorPoints()

--- a/SharpPlot/Canvas/Figure/Figure.cs
+++ b/SharpPlot/Canvas/Figure/Figure.cs
@@ -14,8 +14,6 @@ namespace SharpPlot.Canvas.Figure
         #endregion
     
         #region Properties
-
-        protected internal virtual PlotType PlotType => PlotType.Plot;
         public FigureProperties Properties { get; protected internal set; } = new FigureProperties();
         protected internal virtual string PlotInit => " '-' ";
         internal string HeaderPlot => _getHeaderPlot();
@@ -78,23 +76,23 @@ namespace SharpPlot.Canvas.Figure
         #endregion
     }
     
-    public class Scatter2D : Figure
+    public class Scatter : Figure
     {
         #region Methods
         protected override string _getOptions()
         {
-            return $"u 1:2 {Shape.Points} {Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
+            return $"u {Data.OptDim} {Shape.Points} {Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
         }
         #endregion
 
     }
     
-    public class Line2D : Figure
+    public class Line : Figure
     {
         #region Methods
         protected override string _getOptions()
         {
-            return $"u 1:2 {Shape.Lines} {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
+            return $"u {Data.OptDim} {Shape.Lines} {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
         }
         #endregion
 
@@ -111,13 +109,13 @@ namespace SharpPlot.Canvas.Figure
         #endregion
     }
 
-    public class LinePoints2D : Figure
+    public class LinePoints : Figure
     {
         #region Methods
 
         protected override string _getOptions()
         {
-            return $"u 1:2 {Shape.LinesPoints} {Properties.OptWidth} {Properties.OptDashType} " +
+            return $"u {Data.OptDim} {Shape.LinesPoints} {Properties.OptWidth} {Properties.OptDashType} " +
                    $"{Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
         }
 
@@ -132,53 +130,6 @@ namespace SharpPlot.Canvas.Figure
         {
             return $"u 1:2:3 {Shape.YErr} {Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
         }
-        #endregion
-    } 
-
-    public class Scatter3D : Figure
-    {
-        #region Properties
-        protected internal override PlotType PlotType => PlotType.Splot;
-        #endregion
-        
-        #region Methods
-        protected override string _getOptions()
-        {
-            return $"u 1:2:3 {Shape.Points} {Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
-        }
-        #endregion
-    }
-
-    public class Line3D : Figure
-    {
-        #region Properties
-        protected internal override PlotType PlotType => PlotType.Splot;
-        #endregion
-        
-        #region Methods
-
-        protected override string _getOptions()
-        {
-            return $"u 1:2:3 {Shape.Lines} {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
-        }
-
-        #endregion
-    }
-    
-    public class LinePoints3D : Figure
-    {
-        #region Properties
-        protected internal override PlotType PlotType => PlotType.Splot;
-        #endregion
-        
-        #region Methods
-
-        protected override string _getOptions()
-        {
-            return $"u 1:2:3 {Shape.LinesPoints} {Properties.OptWidth} {Properties.OptDashType} " +
-                   $"{Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
-        }
-
         #endregion
     }
 

--- a/SharpPlot/Canvas/Figure/Figure.cs
+++ b/SharpPlot/Canvas/Figure/Figure.cs
@@ -40,7 +40,7 @@ namespace SharpPlot.Canvas.Figure
 
         private string _getHeaderPlot()
         {
-            return PlotInit + Options + Properties.OptTitle;
+            return PlotInit + Options + " " + Properties.OptTitle;
         }
 
         protected virtual string _getOptions()
@@ -129,7 +129,7 @@ namespace SharpPlot.Canvas.Figure
         #region Methods
         protected override string _getOptions()
         {
-            return $"u 1:2 with points {Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
+            return $"u 1:2 {Shape.Points} {Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
         }
         #endregion
 
@@ -140,7 +140,7 @@ namespace SharpPlot.Canvas.Figure
         #region Methods
         protected override string _getOptions()
         {
-            return $"u 1:2 with lines {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
+            return $"u 1:2 {Shape.Lines} {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
         }
         #endregion
 
@@ -158,7 +158,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2:3 with filledcurve {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
+            return $"u 1:2:3 {Shape.FilledCurve} {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
         }
 
         private List<string> _getDataPoints()
@@ -181,7 +181,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2 with linespoints {Properties.OptWidth} {Properties.OptDashType} " +
+            return $"u 1:2 {Shape.LinesPoints} {Properties.OptWidth} {Properties.OptDashType} " +
                    $"{Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
         }
 
@@ -199,7 +199,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2:3 with yerr {Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
+            return $"u 1:2:3 {Shape.YErr} {Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
         }
         
         private List<string> _getDataPoints()
@@ -225,7 +225,7 @@ namespace SharpPlot.Canvas.Figure
         #region Methods
         protected override string _getOptions()
         {
-            return $"u 1:2:3 with points {Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
+            return $"u 1:2:3 {Shape.Points} {Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
         }
         #endregion
     }
@@ -240,7 +240,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2:3 with lines {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
+            return $"u 1:2:3 {Shape.Lines} {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
         }
 
         #endregion
@@ -256,7 +256,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2:3 with linespoints {Properties.OptWidth} {Properties.OptDashType} " +
+            return $"u 1:2:3 {Shape.LinesPoints} {Properties.OptWidth} {Properties.OptDashType} " +
                    $"{Properties.OptSize} {Properties.OptMarker} {Properties.OptColor}";
         }
 
@@ -290,7 +290,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2 with impulses {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
+            return $"u 1:2 {Shape.Impulses} {Properties.OptWidth} {Properties.OptDashType} {Properties.OptColor}";
         }
 
         #endregion
@@ -302,7 +302,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2:({Properties.Width}) with boxes {Properties.OptColor}";
+            return $"u 1:2:({Properties.Width}) {Shape.Boxes} {Properties.OptColor}";
         }
         
         #endregion
@@ -321,7 +321,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:({Properties.Width}) smooth freq with boxes {Properties.OptColor}";
+            return $"u 1:({Properties.Width}) smooth freq {Shape.Boxes} {Properties.OptColor}";
         }
 
         private IEnumerable<double> _preparePoints()
@@ -396,7 +396,7 @@ namespace SharpPlot.Canvas.Figure
 
         protected override string _getOptions()
         {
-            return $"u 1:2:3:4 with vector {Properties.OptWidth} {Properties.OptColor}";
+            return $"u 1:2:3:4 {Shape.Vector} {Properties.OptWidth} {Properties.OptColor}";
         }
 
         private List<string> _getVectorPoints()

--- a/SharpPlot/Canvas/Figure/FigureProperties.cs
+++ b/SharpPlot/Canvas/Figure/FigureProperties.cs
@@ -5,7 +5,7 @@ namespace SharpPlot.Canvas.Figure
     public class FigureProperties
     {
         
-        #region Properties
+        #region Values
         public double Size { get; protected internal set; } = 1;
         public Color Color { get; protected internal set; } = Color.Black;
         public DashType DashType { get; protected internal set; } = DashType.Solid;
@@ -13,6 +13,15 @@ namespace SharpPlot.Canvas.Figure
         public double Width { get; protected internal set; } = 1.0;
         public string Function { get; protected internal set; } = "";
         public string Title { get; protected internal set; } = "";
+        #endregion
+
+        #region OptionsCommand
+        internal string OptSize => $"ps {Size}";
+        internal string OptColor => $"lc rgb '{Color.ToString().ToLower()}'";
+        internal string OptDashType => $"dt {(int) DashType}";
+        internal string OptMarker => $"pt {(int) Marker}";
+        internal string OptWidth => $"lw {Width}";
+        internal string OptTitle => $"title '{Title}'";
         #endregion
     }
 }

--- a/SharpPlot/Canvas/Figure/Shape.cs
+++ b/SharpPlot/Canvas/Figure/Shape.cs
@@ -1,0 +1,18 @@
+namespace SharpPlot.Canvas.Figure
+{
+    internal static class Shape
+    {
+        #region Properties
+        private const string With = "with ";
+        internal static string Points => With + "points";
+        internal static string Lines => With + "lines";
+        internal static string FilledCurve => With + "filledcurve";
+        internal static string LinesPoints => With + "linespoints";
+        internal static string YErr => With + "yerr";
+        internal static string Impulses => With + "impulses";
+        internal static string Boxes => With + "boxes";
+        internal static string Vector => With + "vector";
+        #endregion
+
+    }
+}

--- a/SharpPlot/Gnuplot.cs
+++ b/SharpPlot/Gnuplot.cs
@@ -186,15 +186,7 @@ namespace SharpPlot
             WriteCommand($"set style fill solid {alpha}");
         }
 
-        private static bool _checkCommensurability(IEnumerable<IEnumerable<double>> z)
-        {
-            var lengths = z.Select(e => e.Count()).ToList();
-            var commensurate = lengths.Aggregate(true, (current, t) => (current && (t == lengths.First())));
-            if (!commensurate) {throw new ApplicationException($"[!] Shape: {string.Join(", ", lengths)}");}
-            return true;
-        }
-        
-        
+
         public static (int, TFigure) Plot<TFigure>(DataPoints dp)
             where TFigure : Figure, new()  
         {
@@ -234,7 +226,6 @@ namespace SharpPlot
         public static (int, TFigure) Plot<TFigure>(IEnumerable<double> x, IEnumerable<double> y) 
             where TFigure : Figure, new()
         {
-            _checkCommensurability(new [] {x, y});
             var fig = new TFigure { Data = new DataPoints(x: x, y: y) };
             var figId = _getNextId();
             _figuresDict.Add(figId, fig);
@@ -244,7 +235,6 @@ namespace SharpPlot
         public static (int, TFigure) Plot<TFigure>(IEnumerable<double> x, IEnumerable<double> y, IEnumerable<double> z) 
             where TFigure : Figure, new()
         {
-            _checkCommensurability(new [] {x, y, z});
             var fig = new TFigure { Data = new DataPoints(x: x, y: y, z: z)};
             var figId = _getNextId();
             _figuresDict.Add(figId, fig);
@@ -255,7 +245,6 @@ namespace SharpPlot
             IEnumerable<double> x1, IEnumerable<double> x2, IEnumerable<double> y1, IEnumerable<double> y2) 
             where TFigure : Figure, new()
         {
-            _checkCommensurability(new [] {x1, x2, y1, y2});
             var fig = new TFigure { Data = new DataPoints(x1: x1, x2: x2, y1: y1, y2: y2)};
             var figId = _getNextId();
             _figuresDict.Add(figId, fig);
@@ -274,7 +263,6 @@ namespace SharpPlot
         public static (int, TFigure) Plot<TFigure>(DataSet ds) 
             where TFigure : Figure, new()
         {
-            _checkCommensurability(new [] {ds[AxisName.X], ds[AxisName.Y]});
             var fig = new TFigure { Data = new DataPoints(x: ds[AxisName.X], ds[AxisName.Y]) };
             var figId = _getNextId();
             _figuresDict.Add(figId, fig);
@@ -286,7 +274,6 @@ namespace SharpPlot
             Marker marker = Marker.ColoredCircle, Color color = Color.Black)
             where TFigure : Figure, new()
         {
-            _checkCommensurability(new [] {x, y});
             var fig = new TFigure {
                 Data = new DataPoints(x: x, y: y),
                 Properties =
@@ -307,7 +294,6 @@ namespace SharpPlot
             Marker marker = Marker.ColoredCircle, Color color = Color.Black)
             where TFigure : Figure, new()
         {
-            _checkCommensurability(new [] {x, y, z});
             var fig = new TFigure {
                 Data = new DataPoints(x: x, y: y, z:z),
                 Properties =
@@ -328,7 +314,6 @@ namespace SharpPlot
             Marker marker = Marker.ColoredCircle, Color color = Color.Black)
             where TFigure : Figure, new()
         {
-            _checkCommensurability(new[] {ds[AxisName.X], ds[AxisName.Y]});
             var fig = new TFigure {
                 Data = new DataPoints(x: ds[AxisName.X], y: ds[AxisName.Y]), 
                 Properties =

--- a/SharpPlot/Gnuplot.cs
+++ b/SharpPlot/Gnuplot.cs
@@ -195,10 +195,38 @@ namespace SharpPlot
         }
         
         
+        public static (int, TFigure) Plot<TFigure>(DataPoints dp)
+            where TFigure : Figure, new()  
+        {
+            var fig = new TFigure{ Data = dp };
+            var figId = _getNextId();
+            _figuresDict.Add(figId, fig);
+            return (figId, fig);
+            
+        }
+
+        public static (int, TFigure) Plot<TFigure>(DataPoints dp, string title,
+            double size = 1, double width = 1.0, DashType dashType = DashType.Solid,
+            Marker marker = Marker.ColoredCircle, Color color = Color.Black)
+            where TFigure : Figure, new()  
+        {
+            var fig = new TFigure{ 
+                Data = dp,               
+                Properties =
+                {
+                    Color = color, Marker = marker, 
+                    DashType = dashType, Size = size, 
+                    Title = title, Width = width
+                }
+            };
+            var figId = _getNextId();
+            _figuresDict.Add(figId, fig);
+            return (figId, fig);
+        }
         public static (int, TFigure) Plot<TFigure>(IEnumerable<double> x) 
             where TFigure : Figure1D, new()
         {
-            var fig = new TFigure {ArrX = x.ToArray()};
+            var fig = new TFigure { Data = new DataPoints(x: x)};
             var figId = _getNextId();
             _figuresDict.Add(figId, fig);
             return (figId, fig);
@@ -207,7 +235,7 @@ namespace SharpPlot
             where TFigure : Figure, new()
         {
             _checkCommensurability(new [] {x, y});
-            var fig = new TFigure {ArrX = x.ToArray(), ArrY = y};
+            var fig = new TFigure { Data = new DataPoints(x: x, y: y) };
             var figId = _getNextId();
             _figuresDict.Add(figId, fig);
             return (figId, fig);
@@ -217,25 +245,25 @@ namespace SharpPlot
             where TFigure : Figure, new()
         {
             _checkCommensurability(new [] {x, y, z});
-            var fig = new TFigure {ArrX = x, ArrY = y, ArrZ1 = z};
+            var fig = new TFigure { Data = new DataPoints(x: x, y: y, z: z)};
             var figId = _getNextId();
             _figuresDict.Add(figId, fig);
             return (figId, fig);
         }
         
         public static (int, TFigure) Plot<TFigure>(
-            IEnumerable<double> x, IEnumerable<double> y, IEnumerable<double> z1, IEnumerable<double> z2) 
+            IEnumerable<double> x1, IEnumerable<double> x2, IEnumerable<double> y1, IEnumerable<double> y2) 
             where TFigure : Figure, new()
         {
-            _checkCommensurability(new [] {x, y, z1, z2});
-            var fig = new TFigure {ArrX = x, ArrY = y, ArrZ1 = z1, ArrZ2 = z2};
+            _checkCommensurability(new [] {x1, x2, y1, y2});
+            var fig = new TFigure { Data = new DataPoints(x1: x1, x2: x2, y1: y1, y2: y2)};
             var figId = _getNextId();
             _figuresDict.Add(figId, fig);
             return (figId, fig);
         }
         
         public static (int, TFigure) Plot<TFigure>(string function) 
-            where TFigure : Figure, new()
+            where TFigure : Function, new()
         {
             var fig = new TFigure(){ Properties = {Function = function}};
             var figId = _getNextId();
@@ -247,7 +275,7 @@ namespace SharpPlot
             where TFigure : Figure, new()
         {
             _checkCommensurability(new [] {ds[AxisName.X], ds[AxisName.Y]});
-            var fig = new TFigure {ArrX = ds[AxisName.X], ArrY = ds[AxisName.Y]};
+            var fig = new TFigure { Data = new DataPoints(x: ds[AxisName.X], ds[AxisName.Y]) };
             var figId = _getNextId();
             _figuresDict.Add(figId, fig);
             return (figId, fig);
@@ -260,8 +288,7 @@ namespace SharpPlot
         {
             _checkCommensurability(new [] {x, y});
             var fig = new TFigure {
-                ArrX = x, 
-                ArrY = y, 
+                Data = new DataPoints(x: x, y: y),
                 Properties =
                 {
                     Color = color, Marker = marker, 
@@ -282,9 +309,7 @@ namespace SharpPlot
         {
             _checkCommensurability(new [] {x, y, z});
             var fig = new TFigure {
-                ArrX = x, 
-                ArrY = y,
-                ArrZ1 = z,
+                Data = new DataPoints(x: x, y: y, z:z),
                 Properties =
                 {
                     Color = color, Marker = marker, 
@@ -305,8 +330,7 @@ namespace SharpPlot
         {
             _checkCommensurability(new[] {ds[AxisName.X], ds[AxisName.Y]});
             var fig = new TFigure {
-                ArrX = ds[AxisName.X], 
-                ArrY = ds[AxisName.Y], 
+                Data = new DataPoints(x: ds[AxisName.X], y: ds[AxisName.Y]), 
                 Properties =
                 {
                     Color = color, Marker = marker, 


### PR DESCRIPTION
This pull-requests modifies `Figure` Class to improve input data handling and usability. The following changes have been applied:

- New `DataPoints` class replaces internal IEnumerable<> attributes `ArrX`, `ArrY`, `ArrZ1` and `ArrZ2`. Thanks to this, the generic `Figure` class does not store streaming point logic and delegates it to `DataPoints.StreamPoints()` method. Only `Histogram` class defines its own special stream points method.
- The input data size check is now inspected within `DataPoints` class instead of every `Gnuplot.Plot<>` call.
- `Scatter`, `Line` and `LinePoints` classes replace `Scatter2D`, `Scatter3D`, `Line2D`, `Line3D`, `LinePoints2D` and `LinePoints3D`. They are now compatible with 2D and 3D plots.
- Each `_getOptions()` call returns a set of predefined command properties, based on:
  - `DataPoints` dimension (1, 1:2, 1:2:3 ...).
  - Figure `Shape` ( with points, with lines, with impulses ...).
  - `FigureProperties` (size, color, marker ...).